### PR TITLE
Updated podspec file with required 'authors' and 'summary'

### DIFF
--- a/CKCalendar.podspec
+++ b/CKCalendar.podspec
@@ -8,4 +8,6 @@ s.source   = { :git => 'https://github.com/lukaszmargielewski/CKCalendar.git', :
 s.source_files = 'Source/*.{h,m}'
 s.requires_arc = true
 s.resources = 'Source/resources/**'
+s.authors = 'Jason Kozemczak'
+s.summary = 'Calendar view'
 end


### PR DESCRIPTION
Working correctly on my fork.
Authors and summary seems to be compulsory fields in podspec files with Cocoa Pods 1.0.0.
